### PR TITLE
Fix Wording in Updating the View of the Tree

### DIFF
--- a/draft-ietf-keytrans-protocol.md
+++ b/draft-ietf-keytrans-protocol.md
@@ -506,10 +506,10 @@ updated tree head, it first provides a consistency proof to show that the new
 tree head is an extension of the previous one. It then also provides the
 following:
 
-- Starting with the log entry that was advertised by the user, compute its
-  direct path in the new implicit binary search tree.
-  Provide the log entry timestamp for each element of the direct path that's to
-  the right of the advertised log entry.
+- Starting with the log entry that was the oldest in the tree corresponding to
+  the user-advertised size, compute its direct path in the new implicit binary
+  search tree. Provide the log entry timestamp for each element of the direct
+  path that's to the right of the advertised log entry.
 - Exactly one of these log entries will lie on the new tree's frontier. From
   this log entry, compute the remainder of the frontier. That is, compute the
   log entry's right child, the right child's right child, and so on. Provide

--- a/draft-ietf-keytrans-protocol.md
+++ b/draft-ietf-keytrans-protocol.md
@@ -506,8 +506,8 @@ updated tree head, it first provides a consistency proof to show that the new
 tree head is an extension of the previous one. It then also provides the
 following:
 
-- Starting with the log entry that was the oldest in the tree corresponding to
-  the user-advertised size, compute its direct path in the new implicit binary
+- Starting with the rightmost log entry from the tree that was advertised by
+  the user, compute its direct path in the new implicit binary
   search tree. Provide the log entry timestamp for each element of the direct
   path that's to the right of the advertised log entry.
 - Exactly one of these log entries will lie on the new tree's frontier. From


### PR DESCRIPTION
The problem with the old phrasing is that the user did not advertise a log entry, they advertised a tree size. I think this should be the oldest node in the tree that corresponds to the user-advertised size.