### PR TITLE
Shorter description of prefix proofs

### DIFF
--- a/draft-ietf-keytrans-protocol.md
+++ b/draft-ietf-keytrans-protocol.md
@@ -1293,9 +1293,9 @@ entry timestamps that the user is expected to have retained are excluded from
 `prefix_proofs` MAY contain multiple `PrefixProof` structures for the same log
 entry. Users MUST verify that all `PrefixProof` structures corresponding to the
 same log entry compute the same prefix tree root hash. There MAY be elements of
-`prefix_proofs` or `prefix_roots` that correspond to log entries whose timestamp
-is not included in `timestamps` but only if the user is expected to have
-retained the log entry's timestamp.
+`prefix_proofs` or `prefix_roots` that correspond to log entries whose timestamps
+are not included in `timestamps` if the user is expected to have
+retained the timestamps from a previous query response.
 
 Users processing a `CombinedTreeProof` MUST verify that each field contains
 exactly the expected number of entries -- no more and no less.

--- a/draft-ietf-keytrans-protocol.md
+++ b/draft-ietf-keytrans-protocol.md
@@ -1284,20 +1284,18 @@ algorithm the user is executing would request them. The elements of the
 hashes for any log entries whose timestamp was provided in `timestamps` but a
 search proof was not provided in `prefix_proofs`.
 
-If a log entry's timestamp is referenced multiple times, it is only added to
-`timestamps` the first time. Additionally, when a user advertises a
-previously-observed tree size in their request, log entry timestamps that the
-user is expected to have retained are excluded from `timestamps`.
+If a log entry's timestamp is referenced multiple times, its timestamp MUST NOT
+be repeated in `timestamps` but MUST only be added the first time. Additionally,
+when a user advertises a previously-observed tree size in their request, log
+entry timestamps that the user is expected to have retained are excluded from
+`timestamps`.
 
-The `prefix_proofs` array differs from the `timestamps` array in two important
-ways. First, it is possible for multiple `PrefixProof` structures from the same log entry to appear in the
-`prefix_proofs` array if the same log entry is referenced multiple times. Users MUST verify that all
-`PrefixProof` structures corresponding to the same log entry compute the same
-prefix tree root hash. Second, while every log entry with a timestamp in
-`timestamps` will also be referenced in either `prefix_proofs` or
-`prefix_roots`, the inverse is not true. There may be elements of
-`prefix_proofs` or `prefix_roots` that correspond to log entries that are not in
-`timestamps` if the user is expected to have retained the log entry's timestamp.
+`prefix_proofs` MAY contain multiple `PrefixProof` structures for the same log
+entry. Users MUST verify that all `PrefixProof` structures corresponding to the
+same log entry compute the same prefix tree root hash. There MAY be elements of
+`prefix_proofs` or `prefix_roots` that correspond to log entries whose timestamp
+is not included in `timestamps` but only if the user is expected to have
+retained the log entry's timestamp.
 
 Users processing a `CombinedTreeProof` MUST verify that each field contains
 exactly the expected number of entries -- no more and no less.


### PR DESCRIPTION
I found the wording of:
> The `prefix_proofs` array differs from the `timestamps` array in two important ways.

Confusing because it is not specified how they are the same. Or put differently, it's silently assumed that `prefix_proofs` and `timestamps` are similar. I think it's clearer if we only describe how `prefix_proofs` is structured, and I used more spec-language (may, must, must not, etc.).