### PR TITLE
Improve algorithm descriptions

### DIFF
--- a/draft-ietf-keytrans-protocol.md
+++ b/draft-ietf-keytrans-protocol.md
@@ -656,8 +656,7 @@ recurses to left or right children, each time starting back at step 1.
    right child always exists, as the rightmost log entry cannot exceed its
    maximum lifetime by definition.
 3. Obtain a binary ladder from the current log entry for the target version.
-   Accounting for any inclusion or non-inclusion proofs which were omitted,
-   verify that the binary ladder terminates in a way that is consistent with
+   Verify that the binary ladder terminates in a way that is consistent with
    previously inspected log entries. Specifically, verify that it indicates a
    maximum version greater than or equal to any log entries to the left, and
    less than or equal to any log entries to the right.
@@ -834,12 +833,12 @@ entry:
 3. If the computed list is empty, leave the position-version pair in the map
    and move on to the next map entry.
 4. For each log entry in the computed list, from left to right:
-   1. Check if a binary ladder from this log entry was already provided in the
+   1. Check if a binary ladder for this log entry was already provided in the
       same query response. If so:
       1. If the previously provided binary ladder had a greater target version
          than the current map entry, then this version of the label no longer
-         needs to be monitored. Remove the current position-version pair (the
-         one with the lesser version) from the map and move on to the next map
+         needs to be monitored. Remove the position-version pair with the
+         the lesser version from the map and move on to the next map
          entry.
       2. If it had a version less than or equal to that of the current map
          entry, terminate and return an error to the user.
@@ -953,21 +952,15 @@ starts at the rightmost distinguished log entry, or the root of the implicit
 binary search tree if there are no distinguished log entries, and then recurses
 down the remainder of the frontier, each time starting back at step 1:
 
-1. Verify that the log entry's timestamp is consistent with the timestamps of
-   all ancestor log entries. That is, verify the log entry's timestamp is
-   greater than or equal to that of its parent.
-2. Obtain a binary ladder from the current log entry for the target version.
-   Accounting for any inclusion or non-inclusion proofs which were omitted,
-   verify that the binary ladder terminates in a way that is consistent with
-   previously inspected log entries. Specifically, verify that it indicates a
+1. Obtain a binary ladder from the current log entry for the target version. If
+   this is not the starting log entry, verify that the binary ladder indicates a
    maximum version greater than or equal to that of its parent log entry.
-3. If this is the rightmost log entry, verify the binary ladder terminates in a
-   way that is consistent with the target version being the greatest that
-   exists. This means that it does not terminate early, all lookups for versions
-   less than or equal to the target version produce inclusion proofs, and all
-   lookups for versions greater than the target version produce non-inclusion
-   proofs.
-4. If this is not the rightmost log entry, recurse to the current log entry's
+2. If this is the rightmost log entry, verify the binary ladder terminates in a
+   way that proves the target version to be the greatest that exists. This means
+   that it does not terminate early, all lookups for versions less than or equal
+   to the target version produce inclusion proofs, and all lookups for versions
+   greater than the target version produce non-inclusion proofs.
+3. If this is not the rightmost log entry, recurse to the current log entry's
    right child.
 
 If the starting log entry was not distinguished or if the starting log entry did

--- a/draft-ietf-keytrans-protocol.md
+++ b/draft-ietf-keytrans-protocol.md
@@ -1335,7 +1335,9 @@ indicates what the terminal node of the search for that value was:
 - `nonInclusionParent` for a parent node that lacks the desired child.
 
 The `depth` field indicates the depth of the terminal node of the search, and is
-provided to assist proof verification.
+provided to assist proof verification. The root node of the prefix tree
+corresponds to a depth of 0, the root's children correspond to a depth of 1, and
+so on recursively.
 
 The `elements` array consists of the fewest node values that can be hashed
 together with the provided leaves to produce the root. The contents of the

--- a/draft-ietf-keytrans-protocol.md
+++ b/draft-ietf-keytrans-protocol.md
@@ -843,14 +843,14 @@ entry:
          entry.
       2. If it had a version less than or equal to that of the current map
          entry, terminate and return an error to the user.
-   2. Receive and verify a binary ladder from this log entry, where the target
+   2. Receive and verify a binary ladder from this log entry where the target
       version is the version currently in the map. This proves that, at the
       indicated log entry, the greatest version present is greater than or equal
       to the previously observed version.
    3. If the above check fails, terminate and return an error to the user.
       Otherwise, remove the current position-version pair from the map and
-      replace it with a new one, with the position of the log entry the binary
-      ladder came from.
+      replace it with a new one for the position of the log entry that the
+      binary ladder came from.
 
 Once the map entries are updated according to this process, the final step of
 monitoring is to remove all mappings where the position corresponds to a
@@ -902,7 +902,7 @@ distinguished log entries.
 Users often wish to search for the "most recent" version, or the greatest
 version, of a label. Unlike searches for a specific version, label owners
 regularly verify that the greatest version is correctly represented in the
-log. This enables a more efficient approach to searching.
+log. This enables a simpler, more efficient approach to searching.
 
 {{distinguished-log-entries}} defines the
 concept of a distinguished log entry, which is any log entry that label owners
@@ -948,12 +948,10 @@ non-distinguished log entry:
 ## Algorithm
 
 The algorithm for performing a greatest-version search (a search for the
-greatest version of a label) is described below as two recursive algorithms.
-
-The first algorithm starts at the rightmost distinguished log entry, or the root
-of the implicit binary search tree if there are no distinguished log entries,
-and then recurses down the remainder of the frontier, each time starting back at
-step 1:
+greatest version of a label) is described below as a recursive algorithm. It
+starts at the rightmost distinguished log entry, or the root of the implicit
+binary search tree if there are no distinguished log entries, and then recurses
+down the remainder of the frontier, each time starting back at step 1:
 
 1. Verify that the log entry's timestamp is consistent with the timestamps of
    all ancestor log entries. That is, verify the log entry's timestamp is
@@ -963,46 +961,17 @@ step 1:
    verify that the binary ladder terminates in a way that is consistent with
    previously inspected log entries. Specifically, verify that it indicates a
    maximum version greater than or equal to that of its parent log entry.
-3. If this is the rightmost log entry, verify that the binary ladder terminates
-   in a way that is consistent with the target version being the greatest that
+3. If this is the rightmost log entry, verify the binary ladder terminates in a
+   way that is consistent with the target version being the greatest that
    exists. This means that it does not terminate early, all lookups for versions
    less than or equal to the target version produce inclusion proofs, and all
    lookups for versions greater than the target version produce non-inclusion
    proofs.
-4. If this is the rightmost log entry, move on to the steps described below. If
-   not, recurse to the current log entry's right child.
+4. If this is not the rightmost log entry, recurse to the current log entry's
+   right child.
 
-If the algorithm above was able to start at a distinguished log entry, and this
-log entry contained the target label-version pair, this indicates that the
-label-version pair was inserted outside of the Reasonable Monitoring Window. As
-such, the user can assume that the label's greatest version was found and that
-the associated commitment to the label-version pair's value is correct, and
-terminate its search successfully.
-
-If the algorithm was not able to start at a distinguished log entry, or the
-starting log entry did not contain the target label-version pair, this indicates
-that the label-version pair was inserted recently (within the Reasonable
-Monitoring Window) and that the user must perform a binary search for the first
-log entry to contain the label-version pair (similar to a fixed-version search).
-
-The second algorithm performs this binary search by starting at the left child,
-if it exists, of the first frontier log entry that contains the target
-label-version pair, as identified by the first algorithm. It then recurses to
-left or right children, each time starting back at step 1:
-
-1. Verify that the log entry's timestamp is consistent with the timestamps of
-   all ancestor log entries.
-2. Obtain a binary ladder from the current log entry for the target version.
-   Verify that the binary ladder terminates in a way that is consistent with
-   previously inspected log entries.
-3. If the binary ladder was terminated early due to a non-inclusion proof for a
-   version less than or equal the target version, recurse to the log entry's
-   right child. If not, recurse to the log entry's left child. If, in either
-   case, recursion isn't possible because the search is at a leaf node, then
-   terminate the search successfully.
-
-Note that if the starting log entry was not distinguished or if the starting log
-entry did not contain the greatest version of the label, then the user may be
+If the starting log entry was not distinguished or if the starting log entry did
+not contain the greatest version of the label, note that the user may be
 obligated to monitor the label in the future per
 {{reasonable-monitoring-window}}.
 

--- a/draft-ietf-keytrans-protocol.md
+++ b/draft-ietf-keytrans-protocol.md
@@ -726,7 +726,7 @@ Window** (RMW), which is the frequency with which the Transparency Log generally
 expects label owners to perform monitoring. The log entry maximum lifetime, if
 defined, MUST be greater than the RMW.
 
-**Distinguished** log entries are chosen according to the algorithm below such that there is roughly one per
+**Distinguished** log entries are chosen according to the algorithm below, such that there is roughly one per
 every interval of the RMW. If a user looks up a label, either through a
 fixed-version or greatest-version search, and finds that the first log entry
 containing their desired label-version pair is to the right of the rightmost
@@ -837,17 +837,23 @@ entry:
 3. If the computed list is empty, leave the position-version pair in the map
    and move on to the next map entry.
 4. For each log entry in the computed list, from left to right:
-   1. Check if this log entry already has an entry in the map with a greater
-      version. If so, this version of the label no longer needs to be monitored.
-      Remove the current position-version pair (the one with the lesser version)
-      from the map and move on to the next map entry.
-   2. Receive and verify a binary ladder from this log entry, where the target version is the
-      version currently in the map. This proves that, at the indicated log
-      entry, the greatest version present is greater than or equal to the
-      previously observed version.
-   3. If the above check fails, return an error to the user. Otherwise, remove
-      the current position-version pair from the map and replace it with a new
-      one, with the position of the log entry the binary ladder came from.
+   1. Check if a binary ladder from this log entry was already provided in the
+      same query response. If so:
+      1. If the previously provided binary ladder had a greater target version
+         than the current map entry, then this version of the label no longer
+         needs to be monitored. Remove the current position-version pair (the
+         one with the lesser version) from the map and move on to the next map
+         entry.
+      2. If it had a version less than or equal to that of the current map
+         entry, terminate and return an error to the user.
+   2. Receive and verify a binary ladder from this log entry, where the target
+      version is the version currently in the map. This proves that, at the
+      indicated log entry, the greatest version present is greater than or equal
+      to the previously observed version.
+   3. If the above check fails, terminate and return an error to the user.
+      Otherwise, remove the current position-version pair from the map and
+      replace it with a new one, with the position of the log entry the binary
+      ladder came from.
 
 Once the map entries are updated according to this process, the final step of
 monitoring is to remove all mappings where the position corresponds to a
@@ -899,7 +905,7 @@ distinguished log entries.
 Users often wish to search for the "most recent" version, or the greatest
 version, of a label. Unlike searches for a specific version, label owners
 regularly verify that the greatest version is correctly represented in the
-log. This enables a simpler, more efficient approach to searching.
+log. This enables a more efficient approach to searching.
 
 {{distinguished-log-entries}} defines the
 concept of a distinguished log entry, which is any log entry that label owners
@@ -999,8 +1005,8 @@ left or right children, each time starting back at step 1:
    terminate the search successfully.
 
 Note that if the starting log entry was not distinguished or if the starting log
-entry did not contain the greatest version of the label, the user may be
-obligated to monitor the label in the future, per
+entry did not contain the greatest version of the label, then the user may be
+obligated to monitor the label in the future per
 {{reasonable-monitoring-window}}.
 
 


### PR DESCRIPTION
- More explicitly specify greatest-version search.
- Prevent needing multiple PrefixProofs from the same log entry when monitoring
- Specify prefix tree depth is zero-indexed (closes #37)
- Move InclusionProof into CombinedTreeProof

No "real" protocol changes, this is mostly editorial